### PR TITLE
CancellationToken bug fixed

### DIFF
--- a/SerialPortNet.Shared/ManagedSerialPort.cs
+++ b/SerialPortNet.Shared/ManagedSerialPort.cs
@@ -48,6 +48,7 @@
 
         public void Dispose()
         {
+            this.tokenSource.Cancel();
             this.tokenSource.Dispose();
             this.serialPortImplementation.Dispose();
         }
@@ -64,7 +65,7 @@
                     this.ConnectionStatusChanged?.Invoke(this, new ConnectionStatusChangedEventArgs(true));
                 }
 
-                await Task.Delay(500);
+                await Task.Delay(500, token);
             }
         }
 
@@ -83,7 +84,7 @@
                 }
                 else
                 {
-                    await Task.Delay(100);
+                    await Task.Delay(100, token);
                 }
             }
         }


### PR DESCRIPTION
After closing and reopening the port one time or a few times, access to the port was denied. Problem fixed by calling a .Cancel() method on CancellationTokenSource.